### PR TITLE
Add error message to file upload when filesize is too big

### DIFF
--- a/src/components/fileUpload/DefaultFileUploadChild.tsx
+++ b/src/components/fileUpload/DefaultFileUploadChild.tsx
@@ -23,20 +23,23 @@ const getIcon = (
     [FileUploadState.Error]: "upload"
   };
 
-  const onIconClick: { [k in FileUploadState]: any } = {
+  const onIconClickMap: { [k in FileUploadState]: any } = {
     [FileUploadState.Uploading]: onProgressIconClick || noop,
     [FileUploadState.Complete]: onCompleteIconClick || noop,
     [FileUploadState.Unstarted]: onDefaultIconClick || noop,
     [FileUploadState.Error]: onDefaultIconClick || noop
   };
 
+  const onIconClick = onIconClickMap[state || FileUploadState.Unstarted];
+
   return (
-    <div onClick={onIconClick[state || FileUploadState.Unstarted]}>
+    <div onClick={onIconClick}>
       <Icon
         className={classNames(styles.icon, {
           [styles.iconError]: state === FileUploadState.Error,
           [styles.iconUploading]: state === FileUploadState.Uploading,
-          [styles.iconDelete]: state === FileUploadState.Complete
+          [styles.iconDelete]: state === FileUploadState.Complete,
+          [styles.iconClickThrough]: onIconClick === noop
         })}
         type={icons[state || FileUploadState.Unstarted]}
       />

--- a/src/components/fileUpload/FileUpload.tsx
+++ b/src/components/fileUpload/FileUpload.tsx
@@ -122,7 +122,20 @@ export class FileUpload extends React.Component<
             );
           });
         }}
-        onDropRejected={this.props.onError || _.noop}
+        onDropRejected={err => {
+          if (this.props.onError) {
+            this.props.onError(err);
+            if (err && err[0] && err[0].size) {
+              const errorFile = err[0];
+              this.setState({
+                fileInfo: {
+                  name: errorFile.name,
+                  fileSize: errorFile.size
+                }
+              });
+            }
+          }
+        }}
         {...forDropzone}
       >
         {this.props.children || (

--- a/src/components/fileUpload/__tests__/DefaultFileUploadChild.test.tsx
+++ b/src/components/fileUpload/__tests__/DefaultFileUploadChild.test.tsx
@@ -12,7 +12,7 @@ describe("DefaultFileUploadChild", () => {
     expect(wrapper.text()).toEqual("somename");
   });
 
-  it("shows file info if given ", () => {
+  it("shows file info if given", () => {
     const wrapper = mount(
       <DefaultFileUploadChild
         documentType={documentTypes.required}

--- a/src/components/fileUpload/defaultChild.scss
+++ b/src/components/fileUpload/defaultChild.scss
@@ -38,6 +38,10 @@
   height: $space-3;
 }
 
+.iconClickThrough {
+  pointer-events: none;
+}
+
 .textDescription {
   color: $text-color;
 }


### PR DESCRIPTION
* Also make button ignore clicks when it has no effect
* This error has to be kept internally in component state so consumers do not have to handle trivial file upload states